### PR TITLE
fix wikipedia link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ offering a more intuitive and easier way to build command-line interfaces.
 
 Why "Oi"? Why not?
 
-What does it mean? Well... What does it mean to you? Try https://en.wikipedia.org/wiki/Oi_(interjection)
+What does it mean? Well... What does it mean to you? Try `<https://en.wikipedia.org/wiki/Oi_(interjection)>`_
 
 
 Quick Start


### PR DESCRIPTION
When I clicked the wikipedia link in the readme it did not include ending parentheses to the URL, this fix is essential to help users understand how to use this program correctly.